### PR TITLE
Update test screenshot path

### DIFF
--- a/XCSummary/Templates/CMHTMLReportBuilder.m
+++ b/XCSummary/Templates/CMHTMLReportBuilder.m
@@ -142,7 +142,7 @@
         
         [self.fileManager copyItemAtPath:fullPath toPath:[self.htmlResourcePath stringByAppendingPathComponent:imageName] error:nil];
         
-        NSString *localImageName = [NSString stringWithFormat:@"resources/Screenshot_%@.png", activity.uuid.UUIDString];
+        NSString *localImageName = [NSString stringWithFormat:@"Attachments/Screenshot_%@.png", activity.uuid.UUIDString];
         composedString = [NSString stringWithFormat:templateFormat, indentation, @"px", activity.title, activity.finishTimeInterval - activity.startTimeInterval, localImageName];
     }
     else


### PR DESCRIPTION
since in Xcode 9 test screenshot generated in Attachments folder, to make .html able to display the attachment, the `resources` path should be updated. please refer to this issue https://github.com/MacPaw/xcsummary/issues/9